### PR TITLE
Fixes url in labs/01/files/ingest-data.kql

### DIFF
--- a/Allfiles/labs/01/files/ingest-data.kql
+++ b/Allfiles/labs/01/files/ingest-data.kql
@@ -9,5 +9,5 @@
     UnitPrice: real,
     TaxAmount: real)
 
-.ingest into table sales 'https://raw.githubusercontent.com/MicrosoftLearning/mslearn-synapse/master/Allfiles/Labs/01/files/sales.csv' 
+.ingest into table sales 'https://raw.githubusercontent.com/microsoftlearning/mslearn-synapse/master/Allfiles/Labs/01/files/sales.csv' 
 with (ignoreFirstRecord = true)


### PR DESCRIPTION
# Module: dp-203 Explore Azure Synapse Analytics
## Lab/Demo: 01

The URL with capitalization fails container name validation resulting in the following error: 

`Failed to download blob: container\r\nParameter name: Argument 'container' (with value 'MicrosoftLearning') failed to satisfy condition 'Container name must be valid (see https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata)': at EnsureValidContainerName in C:\\__w\\1\\s\\Src\\Common\\Kusto.Cloud.Platform.Azure.Storage\\XStore\\ExtendedBlobContainerClient.cs: line 106`


Changes proposed in this pull request:

- Update file path with lowercase container name to pass the EnsureValidContainerName test.