### PR TITLE
Change Ressource group pattern

### DIFF
--- a/Allfiles/labs/04/setup.ps1
+++ b/Allfiles/labs/04/setup.ps1
@@ -80,7 +80,7 @@ foreach ($provider in $provider_list){
 # Generate unique random suffix
 [string]$suffix =  -join ((48..57) + (97..122) | Get-Random -Count 7 | % {[char]$_})
 Write-Host "Your randomly-generated suffix for Azure resources is $suffix"
-$resourceGroupName = "dp000-$suffix"
+$resourceGroupName = "dp203-$suffix"
 
 # Choose a random region
 Write-Host "Finding an available region. This may take several minutes...";


### PR DESCRIPTION
Change the pattern of ressource group to match the dp203 exam instead of dp000 originally

# Module: 1
## Lab/Demo: 04

Fixes # .

Changes proposed in this pull request:

- fix the ressource groupe name pattern creation for lab 4
-
-