### PR TITLE
Databricks Introduction Lab 23 Fix

### DIFF
--- a/Allfiles/labs/23/setup.ps1
+++ b/Allfiles/labs/23/setup.ps1
@@ -99,7 +99,7 @@ while ($stop -ne 1){
         write-host "$cores of $maxcores cores in use."
         $available_quota = $quota.limit - $quota.currentvalue
     }
-    if (($available_quota -lt 8) -or ($skuOK -eq 0))
+    if (($available_quota -lt 4) -or ($skuOK -eq 0))
     {
         Write-Host "$Region has insufficient capacity."
         $tried_regions.Add($Region)

--- a/Allfiles/labs/24/setup.ps1
+++ b/Allfiles/labs/24/setup.ps1
@@ -99,7 +99,7 @@ while ($stop -ne 1){
         write-host "$cores of $maxcores cores in use."
         $available_quota = $quota.limit - $quota.currentvalue
     }
-    if (($available_quota -lt 8) -or ($skuOK -eq 0))
+    if (($available_quota -lt 4) -or ($skuOK -eq 0))
     {
         Write-Host "$Region has insufficient capacity."
         $tried_regions.Add($Region)


### PR DESCRIPTION
standard_ds3_v2 has 4 core processor and powershell is checking whether vm has 8 cores. So script was throwing error in `$Region as insufficient capacity for all regions`.

After updating if condition, I was able to complete the exercise.

# Module: 00
## Lab/Demo: 23

Fixes # . Updated if condition to check for 4 cores instead of 8 cores.
![image](https://github.com/MicrosoftLearning/dp-203-azure-data-engineer/assets/15905780/69cde1ba-2055-4124-b86e-2f98124ca9f2)

![image](https://github.com/MicrosoftLearning/dp-203-azure-data-engineer/assets/15905780/3aad0ca8-60d3-4757-82c3-2b66493e6484)


Changes proposed in this pull request:

- standard_ds3_v2 is 4 core vm machine, so updated powershell script if condition to check for 4 instead of 8.
-
-