### PR TITLE
Lab24 update

### DIFF
--- a/Instructions/Labs/24-Analyze-Files-in-Azure-Databricks.md
+++ b/Instructions/Labs/24-Analyze-Files-in-Azure-Databricks.md
@@ -54,12 +54,13 @@ Azure Databricks is a distributed processing platform that uses Apache Spark *cl
 1. In the Azure portal, browse to the **dp203-*xxxxxxx*** resource group that was created by the script you ran.
 2. Select the **databricks*xxxxxxx*** Azure Databricks Service resource.
 3. In the **Overview** page for **databricks*xxxxxxx***, use the **Launch Workspace** button to open your Azure Databricks workspace in a new browser tab; signing in if prompted.
-4. If a **What's your current data project?** message is displayed, select **Finish** to close it. Then view the Azure Databricks workspace portal and note that the sidebar on the left side contains icons for the various tasks you can perform. The sidebar expands to show the names of the task categories.
-5. Select the **(+) New** task, and then select **Cluster**.
+4. You may have to revert to the old user interface before proceeding. You can accomplish this by selecting the button Revert to old UI as shown in: ![Revert to old UI](./images/revert-to-old-ui.png)
+5. If a **What's your current data project?** message is displayed, select **Finish** to close it. Then view the Azure Databricks workspace portal and note that the sidebar on the left side contains icons for the various tasks you can perform. The sidebar expands to show the names of the task categories.
+6. Select the **(+) New** task, and then select **Cluster**.
 
     **Note**: If a tip is displayed, use the **Got it** button to close it. This applies to any future tips that may be displayed as you navigate the workspace interface for the first time.
 
-6. In the **New Cluster** page, create a new cluster with the following settings:
+7. In the **New Cluster** page, create a new cluster with the following settings:
     - **Cluster name**: *User Name's* cluster (the default cluster name)
     - **Cluster mode**: Single Node
     - **Access mode** (*if prompted*): Single user
@@ -68,7 +69,7 @@ Azure Databricks is a distributed processing platform that uses Apache Spark *cl
     - **Node type**: Standard_DS3_v2
     - **Terminate after** *30* **minutes of inactivity**
 
-7. Wait for the cluster to be created. It may take a minute or two.
+8. Wait for the cluster to be created. It may take a minute or two.
 
 > **Note**: If your cluster fails to start, your subscription may have insufficient quota in the region where your Azure Databricks workspace is provisioned. See [CPU core limit prevents cluster creation](https://docs.microsoft.com/azure/databricks/kb/clusters/azure-core-limit) for details. If this happens, you can try deleting your workspace and creating a new one in a different region. You can specify a region as a parameter for the setup script like this: `./setup.ps1 eastus`
 
@@ -77,7 +78,7 @@ Azure Databricks is a distributed processing platform that uses Apache Spark *cl
 As in many Spark environments, Databricks supports the use of notebooks to combine notes and interactive code cells that you can use to explore data.
 
 1. Expand the sidebar on the left and select the **Workspace** tab. Then select the **Users** folder and in the **&#9662;** menu for the **&#8962; *your_user_name*** folder, select **Import**.
-2. In the **Import Notebooks** dialog box, select **URL** and import the notebook from `https://github.com/MicrosoftLearning/dp-203-azure-data-engineer/raw/master/Allfiles/labs/24/Databricks-Spark.ipynb`.
+2. In the **Import Notebooks** dialog box, select **URL** and import the notebook from `https://github.com/MicrosoftLearning/dp-203-azure-data-engineer/raw/master/Allfiles/labs/24/Databricks-Sparkipynb`
 3. Select **&#8962; Home** and then open the **Databricks-Spark** notebook you just imported.
 4. Ensure that the notebook is attached to ***User Name's* cluster**, and follow the instructions it contains; running the cells it contains to explore data in files.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- added instruction to switch to old UI (same as in lab 23)
- and fixed numbering because of that
- removed the full stop at the end of the spark notebook url, since it was difficult to copy the link without it, making it so that the student copies the link, pastes in the address bar and then removes the full stop before accessing the link.
