### PR TITLE
Update 15-Synapse-link-sql.md

### DIFF
--- a/Instructions/Labs/15-Synapse-link-sql.md
+++ b/Instructions/Labs/15-Synapse-link-sql.md
@@ -117,6 +117,7 @@ Now you're ready to configure Azure Synapse Link for SQL in your Synapse Analyti
         - **Name**: SqlAdventureWorksLT
         - **Description**: Connection to AdventureWorksLT database
         - **Connect via integration runtime**: AutoResolveIntegrationRuntime
+        - **Version**: Legacy
         - **Connection String**: Selected
         - **From Azure subscription**: Selected
         - **Azure subscription**: *Select your Azure subscription*


### PR DESCRIPTION
Connection string option is not displayed when Version is set to Recommended. This produces an error when starting the linked connection. Switching the Version to Legacy fixes this issue.

# Module: 15
## Lab/Demo: Use Azure Synapse Link for SQL

Fixes # .

Changes proposed in this pull request:

-Add a step in the linked connection configuration to change the Version to Legacy