### PR TITLE
sample provider verification - lab 01

### DIFF
--- a/Allfiles/labs/01/setup.ps1
+++ b/Allfiles/labs/01/setup.ps1
@@ -126,6 +126,29 @@ $Region = $locations.Get($rand).Location
         }
     }
 }
+
+# Ensure that all the required providers have completed registration
+$max_retries = 5
+$wait_time = 30
+foreach ($provider in $provider_list) {
+    $retryCount = 0
+    while ($retryCount -lt $max_retries) {
+        $currentStatus = (Get-AzResourceProvider -ProviderNamespace $provider).RegistrationState
+        if ($currentStatus -eq "Registered") {
+            Write-Host "$provider is successfully registered."
+            break
+        }
+        else {
+            Write-Host "$provider is not yet registered. Waiting for $wait_time seconds before rechecking..."
+            Start-Sleep -Seconds $wait_time
+            $retryCount++
+        }
+    }
+    if ($retryCount -eq $max_retries) {
+        Write-Host "Failed to register $provider after $max_retries attempts."
+    }
+}
+
 Write-Host "Creating $resourceGroupName resource group in $Region ..."
 New-AzResourceGroup -Name $resourceGroupName -Location $Region | Out-Null
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 01

Partially Fixes #135 

Changes proposed in this pull request:

Adds a verification block just prior to the Synapse install that checks the registration state of the required resource providers.